### PR TITLE
API: Remove dependency on verbs

### DIFF
--- a/src/api/snapi_mq.h
+++ b/src/api/snapi_mq.h
@@ -1,8 +1,6 @@
 #ifndef __SNAPI_MQ_H__
 #define __SNAPI_MQ_H__
 
-#include <infiniband/verbs.h>
-
 /**
   * @defgroup SNAPI_DT Library data-structures
   * @{


### PR DESCRIPTION
This is an implementation specific dependency that should not be exposed.

Signed-off-by: Pavel (Pasha) Shamis <pasharesearch@gmail.com>